### PR TITLE
Support https

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "koa-static": "^2.1.0",
     "lodash": "^4.16.4",
     "node-fetch": "^1.6.3",
+    "pem": "^1.9.7",
     "qs": "^6.3.1",
     "socket.io": "^1.7.3",
     "tiny-cookie": "^1.0.1",

--- a/server/index.js
+++ b/server/index.js
@@ -35,6 +35,7 @@ co(function*() {
 
     pem.createCertificate({days:1, selfSigned:true}, function(err, keys){
       const httpsServer = https.createServer({key: keys.serviceKey, cert: keys.certificate}, app.callback());
+      app.io.attach(httpsServer);
       httpsServer.listen(httpsPort, '0.0.0.0');
     })
 

--- a/server/index.js
+++ b/server/index.js
@@ -6,11 +6,14 @@ const koa = require('koa');
 const kcors = require('kcors');
 const koaMount = require('koa-mount');
 const koaStatic = require('koa-static');
+const https = require('https');
+const pem = require('pem');
 const fetch = require('./fetch.js');
 const io = require('./io.js');
 const router = require('./router.js');
 
 const port = process.env.PORT || process.env.LEANCLOUD_APP_PORT || 8080;
+const httpsPort = process.env.HTTPS_PORT || 8443;
 const jsoneditor = koa();
 const app = koa();
 
@@ -30,7 +33,12 @@ co(function*() {
     app.io = io(server);
     server.listen(port, '0.0.0.0'); // IPv4 model
 
-    console.log(`running at port ${port}...`);
+    pem.createCertificate({days:1, selfSigned:true}, function(err, keys){
+      const httpsServer = https.createServer({key: keys.serviceKey, cert: keys.certificate}, app.callback());
+      httpsServer.listen(httpsPort, '0.0.0.0');
+    })
+
+    console.log(`running at port http[${port}] & https[${httpsPort}]...`);
 }).catch((e) => {
     console.log(e.stack);
     process.exit(1);

--- a/server/io.js
+++ b/server/io.js
@@ -1,10 +1,14 @@
 'use strict';
 
 const Cookie = require('../common/cookie');
+const ioServer = require('socket.io');
 
 module.exports = function(server) {
-    const io = require('socket.io')(server);
+    const io = new ioServer()
     io.on('connection', onConnection);
+    if (server) {
+      io.attach(server)
+    }
     return io;
 };
 


### PR DESCRIPTION
Create https server on port 8443 (default). For developers to handle https protocol. Need TRUST the certificate explicitly.